### PR TITLE
fix:🐛fix bug of returning the DateTime in a non-UTC format

### DIFF
--- a/BidUp.Presentation/Infrastructure/DateTimeConverter.cs
+++ b/BidUp.Presentation/Infrastructure/DateTimeConverter.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BidUp.Presentation.Infrastructure;
+
+// Ensures that DateTime values are serialized (written) in UTC format and deserialized (read) as UTC (see: https://github.com/dotnet/runtime/issues/1566).
+public class DateTimeConverter : JsonConverter<DateTime>
+{
+    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.GetDateTime().ToUniversalTime();
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(DateTime.SpecifyKind(value, DateTimeKind.Utc));
+    }
+
+    //// The issue with using DateTime.ToUniversalTime() is that it assumes I save the time in my local timezone but i save it as UTC in the db so it will convert it again to UTC which is will result in an invalid time.
+    // public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    // {
+    //     writer.WriteStringValue(value.ToUniversalTime());
+    // }
+
+}

--- a/BidUp.Presentation/Program.cs
+++ b/BidUp.Presentation/Program.cs
@@ -21,7 +21,11 @@ using Swashbuckle.AspNetCore.Filters;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers()
-                .AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter())); // To serialize enum values to string instead of int
+                .AddJsonOptions(options =>
+                {
+                    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()); // To serialize enum values to string instead of int
+                    options.JsonSerializerOptions.Converters.Add(new DateTimeConverter()); // To serialize and deserailize the date time in UTC format (https://github.com/dotnet/runtime/issues/1566)
+                });
 
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 


### PR DESCRIPTION
**I save all DateTime as UTC in the database. I then parse the UTC time to local time in the client, but by default the JSON serializer didn't append a "Z".
This commit solves that issue by specifying that the time is already in UTC and will only append the 'Z' at the end of it.**