### PR TITLE
feat:⚡add the Refresh Token as an HttpOnly cookie for browser clients

### DIFF
--- a/BidUp.BusinessLogic/DTOs/AuthDTOs/LoginResponse.cs
+++ b/BidUp.BusinessLogic/DTOs/AuthDTOs/LoginResponse.cs
@@ -2,13 +2,17 @@ namespace BidUp.BusinessLogic.DTOs.AuthDTOs;
 
 public class LoginResponse
 {
-    public required int UserId { get; init; }
+    public required UserInfo User { get; set; }
+    public required string AccessToken { get; set; }
+    public required string RefreshToken { get; set; }
+}
+
+public class UserInfo
+{
+    public required int Id { get; init; }
     public required string FirstName { get; init; }
     public required string LastName { get; init; }
     public required string Email { get; init; }
     public string? ProfilePictureUrl { get; init; }
     public required string Role { get; init; }
-    public required string AccessToken { get; set; }
-    public required double ExpiresIn { get; set; }
-    public required string RefreshToken { get; set; }
 }

--- a/BidUp.BusinessLogic/DTOs/AuthDTOs/RefreshRequest.cs
+++ b/BidUp.BusinessLogic/DTOs/AuthDTOs/RefreshRequest.cs
@@ -4,7 +4,5 @@ namespace BidUp.BusinessLogic.DTOs.AuthDTOs;
 
 public class RefreshRequest
 {
-    // This property must be required otherwise the consumer can enter null as a value and get the users who have null value for RefreshToken field in the db
-    [Required]
-    public required string RefreshToken { get; set; }
+    public string? RefreshToken { get; set; }
 }

--- a/BidUp.BusinessLogic/Interfaces/IAuthService.cs
+++ b/BidUp.BusinessLogic/Interfaces/IAuthService.cs
@@ -9,7 +9,7 @@ public interface IAuthService
     Task SendConfirmationEmail(string email, string urlOfConfirmationEndpoint);
     Task<bool> ConfirmEmail(string userId, string token);
     Task<AppResult<LoginResponse>> Login(LoginRequest loginRequest);
-    Task<AppResult<LoginResponse>> Refresh(string refreshToken);
+    Task<AppResult<LoginResponse>> Refresh(string? refreshToken);
     Task SendPasswordResetEmail(string email, string urlOfPasswordResetPage);
     Task<AppResult> ResetPassword(ResetPasswordRequest resetPasswordRequest);
     Task<AppResult> ChangePassword(int userId, ChangePasswordRequest changePasswordRequest);

--- a/BidUp.Presentation/Controllers/AuthController.cs
+++ b/BidUp.Presentation/Controllers/AuthController.cs
@@ -15,6 +15,8 @@ public class AuthController : ControllerBase
 {
     private readonly IAuthService authService;
     private readonly LinkGenerator linkGenerator;
+    const string NameOfRefreshTokenCookie = "RefreshToken";
+
     public AuthController(IAuthService authService, LinkGenerator linkGenerator)
     {
         this.authService = authService;
@@ -65,6 +67,8 @@ public class AuthController : ControllerBase
         return Content(html, "text/html");
     }
 
+
+    /// <response code="200">If the request is sent from a browser client the refreshToken will be set as an http-only cookie and won't be returned in the response body.</response>
     [HttpPost("login")]
     [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
@@ -75,20 +79,35 @@ public class AuthController : ControllerBase
         if (!result.Succeeded)
             return Unauthorized(result.Error);
 
-        return Ok(result.Response);
+        if (IsBrowserClient())
+        {
+            SetRefreshTokenCookie(result.Response!.RefreshToken);
+            return Ok(new { result.Response!.User, result.Response.AccessToken }); // RefreshToken won't returned in the payload
+        }
+        else
+            return Ok(result.Response);
     }
 
+    /// <summary>Browser Clients don't have to send the request body, the server will extract the refresh token from the cookies instead.</summary>
+    /// <response code="200">If the request is sent from a browser client the refreshToken will be set as an http-only cookie and won't be returned in the response body.</response>
     [HttpPost("refresh")]
     [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> RefreshToken(RefreshRequest refreshRequest)
+    public async Task<IActionResult> RefreshToken(RefreshRequest? refreshRequest)
     {
-        var result = await authService.Refresh(refreshRequest.RefreshToken);
+        var refreshToken = IsBrowserClient() ? Request.Cookies[NameOfRefreshTokenCookie] : refreshRequest?.RefreshToken;
 
+        var result = await authService.Refresh(refreshToken);
         if (!result.Succeeded)
             return Unauthorized(result.Error);
 
-        return Ok(result.Response);
+        if (IsBrowserClient())
+        {
+            SetRefreshTokenCookie(result.Response!.RefreshToken);
+            return Ok(new { result.Response!.User, result.Response.AccessToken }); // RefreshToken won't returned in the payload
+        }
+        else
+            return Ok(result.Response);
     }
 
     /*
@@ -145,16 +164,72 @@ public class AuthController : ControllerBase
         return NoContent();
     }
 
-    [HttpPost("revoke-refresh-token")]
+    [HttpPost("Logout")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> RevokeRefreshToken()
+    public async Task<IActionResult> Logout()
     {
         var userId = int.Parse(User.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value!);
 
         await authService.RevokeRefreshToken(userId);
 
+        DeleteRefreshTokenCookie(); // in case of the client is a web client otherwise it has no effect
+
         return NoContent();
+    }
+
+
+    // Determines if the current request from a browser client or not
+    [NonAction]
+    private bool IsBrowserClient()
+    {
+        var userAgent = Request.Headers.UserAgent.ToString().ToLower();
+
+        return userAgent.Contains("mozilla") ||        // Matches most modern browsers
+                userAgent.Contains("chrome") ||        // Google Chrome
+                userAgent.Contains("safari") ||        // Safari (exclude Chrome here)
+                userAgent.Contains("edge") ||          // Microsoft Edge
+                userAgent.Contains("firefox") ||       // Mozilla Firefox
+                userAgent.Contains("opera") ||         // Opera browser
+                userAgent.Contains("msie") ||          // Internet Explorer (older)
+                userAgent.Contains("trident");         // Internet Explorer (newer)
+    }
+
+    // Sets the refresh token as an HTTP-only cookie with CHIPS
+    [NonAction]
+    private void SetRefreshTokenCookie(string refreshToken)
+    {
+        var cookieOptions = new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = true,               // Ensures HTTPS is used
+            SameSite = SameSiteMode.None, // Allows cross-site requests
+            Path = "/",
+            Expires = DateTime.UtcNow.AddMonths(1),
+            IsEssential = true,          // Important for non-tracking cookies
+        };
+
+        // Add Partitioned attribute for CHIPS (https://developers.google.com/privacy-sandbox/cookies/chips)
+        cookieOptions.Extensions.Add("Partitioned");
+
+        Response.Cookies.Append(NameOfRefreshTokenCookie, refreshToken, cookieOptions);
+    }
+
+    [NonAction]
+    private void DeleteRefreshTokenCookie()
+    {
+        var cookieOptions = new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.None,
+            Path = "/",
+            Expires = DateTime.UtcNow.AddDays(7),
+            IsEssential = true,
+        };
+        cookieOptions.Extensions.Add("Partitioned");
+
+        Response.Cookies.Delete(NameOfRefreshTokenCookie, cookieOptions);
     }
 }

--- a/BidUp.Presentation/Program.cs
+++ b/BidUp.Presentation/Program.cs
@@ -141,8 +141,8 @@ builder.Services.AddAutoMapper(typeof(MappingProfile));
 builder.Services.AddSignalR();
 builder.Services.AddCors(options =>
 {
-    // To be able to test signalR hub using JS client
-    options.AddPolicy(name: "DevelopmentPolicy", policy => policy.WithOrigins("http://127.0.0.1:5500").AllowAnyMethod().AllowAnyHeader().AllowCredentials());
+    var frontendOrigin = builder.Configuration["Cors:FrontendOrigin"]!;
+    options.AddPolicy(name: "AllowFrontendDomain", policy => policy.WithOrigins(frontendOrigin).AllowAnyMethod().AllowAnyHeader().AllowCredentials());
 });
 
 builder.Services.AddScoped<IAuthService, AuthService>();
@@ -192,7 +192,7 @@ app.UseHttpsRedirection();
 
 if (app.Environment.IsDevelopment())
 {
-    app.UseCors("DevelopmentPolicy");
+    app.UseCors("AllowFrontendDomain");
 }
 
 app.UseAuthentication(); // Validates the Token came at the request's Authorization header then decode it and assign it to HttpContext.User

--- a/BidUp.Presentation/appsettings.json
+++ b/BidUp.Presentation/appsettings.json
@@ -29,5 +29,8 @@
     "ThumbnailHeight": 200,
     "ProductImageWidth": 600,
     "ProductImageHeight": 600
+  },
+  "Cors": {
+    "FrontendOrigin": "http://192.168.1.9:3000"
   }
 }


### PR DESCRIPTION
Add the refresh token as a Partitioned HttpOnly cookie instead of returning it in the response body for browser clients.