### PR TITLE
fix:🐛reserve refresh token during token refresh to prevent logout issues

### DIFF
--- a/BidUp.BusinessLogic/Services/AuthService.cs
+++ b/BidUp.BusinessLogic/Services/AuthService.cs
@@ -142,7 +142,7 @@ public class AuthService : IAuthService
                 Role = roles.First(),
             },
             AccessToken = CreateAccessToken(user, roles),
-            RefreshToken = await CreateRefreshToken(user)
+            RefreshToken = refreshToken!
         };
 
         return AppResult<LoginResponse>.Success(loginResponse);


### PR DESCRIPTION
Prevent refresh token change during token refresh to avoid unnecessary logout on multiple refreshes for the page at the client side