### PR TITLE
refactor:♻️move MarkAllMessagesAsRead from GET /messages endpoint to a SignalR method

### DIFF
--- a/src/BidX.BusinessLogic/DTOs/ChatDTOs/MarkAllMessagesAsReadRequest.cs
+++ b/src/BidX.BusinessLogic/DTOs/ChatDTOs/MarkAllMessagesAsReadRequest.cs
@@ -1,0 +1,6 @@
+namespace BidX.BusinessLogic.DTOs.ChatDTOs;
+
+public class MarkAllMessagesAsReadRequest
+{
+    public required int ChatId { get; init; }
+}

--- a/src/BidX.BusinessLogic/Interfaces/IChatsService.cs
+++ b/src/BidX.BusinessLogic/Interfaces/IChatsService.cs
@@ -12,6 +12,7 @@ public interface IChatsService
     Task<Result<Page<MessageResponse>>> GetChatMessages(int callerId, int chatId, MessagesQueryParams queryParams);
     Task SendMessage(int senderId, SendMessageRequest request);
     Task MarkMessageAsRead(int readerId, MarkMessageAsReadRequest request);
+    Task MarkAllMessagesAsRead(int readerId, MarkAllMessagesAsReadRequest request);
     Task NotifyUserWithUnreadChatsCount(int userId);
     Task NotifyParticipantsWithUserStatus(int userId, bool isOnline);
 }

--- a/src/BidX.DataAccess/Configs/MessageConfig.cs
+++ b/src/BidX.DataAccess/Configs/MessageConfig.cs
@@ -27,6 +27,8 @@ public class MessageConfig : IEntityTypeConfiguration<Message>
 
         // Needed in GetUserChats for:
         //  - Counting unread received messages by filtering with (ChatId + RecipientId + IsRead)
+        // Needed in MarkAllMessagesAsRead for:
+        //  - Filtering by (ChatId + RecipientId + IsRead)
         builder.HasIndex(m => new { m.ChatId, m.RecipientId, m.IsRead });
 
     }

--- a/src/BidX.Presentation/Controllers/ChatsController.cs
+++ b/src/BidX.Presentation/Controllers/ChatsController.cs
@@ -74,9 +74,6 @@ public class ChatsController : ControllerBase
     }
 
 
-    /// <summary>
-    /// The messages will be marked as read once this endpoint is called
-    /// </summary>
     [HttpGet("{chatId}/messages")]
     [ProducesResponseType(typeof(Page<MessageResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]

--- a/src/BidX.Presentation/Hubs/Chat/Hub.Chat.cs
+++ b/src/BidX.Presentation/Hubs/Chat/Hub.Chat.cs
@@ -21,6 +21,14 @@ public partial class Hub
         await chatsService.MarkMessageAsRead(userId, request);
     }
 
+    [Authorize]
+    public async Task MarkAllMessagesAsRead(MarkAllMessagesAsReadRequest request)
+    {
+        var userId = int.Parse(Context.UserIdentifier!);
+
+        await chatsService.MarkAllMessagesAsRead(userId, request);
+    }
+
     /// <summary>
     /// The client must call this method when the chat page loaded to be able to receive messages updates in realtime
     /// </summary>

--- a/src/BidX.Presentation/Hubs/Notification/Hub.Notification.cs
+++ b/src/BidX.Presentation/Hubs/Notification/Hub.Notification.cs
@@ -1,15 +1,18 @@
 using BidX.BusinessLogic.DTOs.NotificationDTOs;
+using Microsoft.AspNetCore.Authorization;
 
 namespace BidX.Presentation.Hubs;
 
 public partial class Hub
 {
+    [Authorize]
     public async Task MarkNotificationAsRead(MarkNotificationAsReadRequest request)
     {
         var userId = int.Parse(Context.UserIdentifier!);
         await notificationsService.MarkNotificationAsRead(userId, request.NotificationId);
     }
 
+    [Authorize]
     public async Task MarkAllNotificationsAsRead()
     {
         var userId = int.Parse(Context.UserIdentifier!);

--- a/src/BidX.Presentation/appsettings.json
+++ b/src/BidX.Presentation/appsettings.json
@@ -18,10 +18,6 @@
   "Jwt": {
     "AccessTokenExpirationTimeInMinutes": 30
   },
-  "BrevoEmailApi": {
-    "ConfirmationEmailTemplateId": "3",
-    "PasswordResetEmailTemplateId": "5"
-  },
   "Images": {
     "MaxIconSizeAllowed": 262144,
     "MaxImageSizeAllowed": 1048576,
@@ -36,5 +32,9 @@
   "AuthPages":{
     "EmailConfirmationPageUrl":"http://localhost:3000/confirm-email",
     "ResetPasswordPageUrl":"http://localhost:3000/reset-password"
+  },
+  "BrevoEmailApi": {
+    "ConfirmationEmailTemplateId": "3",
+    "PasswordResetEmailTemplateId": "5"
   }
 }


### PR DESCRIPTION
 Because in REST, GET should be:
- Safe: No side effects (e.g., no modifications to the database).
- Idempotent: Multiple identical requests should have the same effect as one.

and this endpoint violates both by updating message status.